### PR TITLE
Input validation: validate each iteration once and drop a dead 31-second query

### DIFF
--- a/db/db_schema.sql
+++ b/db/db_schema.sql
@@ -9129,7 +9129,13 @@ SELECT DISTINCT temporal_scenario_id,
 FROM inputs_temporal
          INNER JOIN
      inputs_temporal_horizon_timepoints
-     USING (temporal_scenario_id, stage_id, timepoint)
+-- subproblem_id is part of both tables' keys: joining on it keeps a
+-- timepoint's horizons within its own subproblem and, because it is the
+-- second column of inputs_temporal_horizon_timepoints' primary key, lets
+-- SQLite use that index (without it the join scanned every horizon-timepoint
+-- row of the temporal scenario for every timepoint: ~30 s for one 8760-hour
+-- subproblem, 0.05 s with it, identical rows)
+     USING (temporal_scenario_id, subproblem_id, stage_id, timepoint)
 ;
 
 -- This view shows the possible operational horizons for each project based

--- a/gridpath/temporal/operations/horizons.py
+++ b/gridpath/temporal/operations/horizons.py
@@ -737,21 +737,14 @@ def validate_inputs(
         conn,
     )
 
-    c = conn.cursor()
-
-    builtin_hrz_types_list = ", ".join(f"'{h}'" for h in BUILTIN_HORIZON_TYPES)
-
-    periods_horizons = c.execute(f"""
-        SELECT balancing_type_horizon, period, horizon
-        FROM periods_horizons
-        WHERE temporal_scenario_id = {subscenarios.TEMPORAL_SCENARIO_ID}
-        AND stage_id = {stage}
-        AND balancing_type_horizon NOT IN ({builtin_hrz_types_list})
-        """)
-
+    # NOTE: this validator used to also query the periods_horizons view here
+    # and never used the result. That query took ~30 s per call on an
+    # 8760-hour scenario (the view's join could not use the horizon-timepoints
+    # index -- see the view definition in db_schema.sql), and the validator
+    # runs once per iteration x subproblem x stage, so it dominated
+    # input-validation time for weather-year ensembles.
     df_hrzs = cursor_to_df(hrzs)
     df_hrz_tmps = cursor_to_df(hrz_tmps)
-    df_periods_hrzs = cursor_to_df(periods_horizons)
 
     # Get expected dtypes
     expected_dtypes = get_expected_dtypes(

--- a/gridpath/validate_inputs.py
+++ b/gridpath/validate_inputs.py
@@ -41,14 +41,19 @@ def validate_inputs(
     scenario_structure,
     loaded_modules,
     scenario_id,
-    weather_iteration,
-    hydro_iteration,
-    availability_iteration,
     subscenarios,
     conn,
 ):
     """ "
-    For each module, load the inputs from the database and validate them
+    For each iteration, subproblem and stage in the scenario structure, and
+    for each module, load the inputs from the database and validate them.
+
+    Call this ONCE per scenario: it iterates over every weather / hydro /
+    availability iteration itself. (Until September 2026 main() also looped
+    over the iterations and called this function once per iteration, so
+    every module validator ran N times per iteration for N iterations --
+    N-squared work; a 15-iteration production-cost ensemble took two hours
+    to validate.)
 
     :param scenario_structure: ScenarioStructure object with info on the
         iteration and subproblem/stage structure
@@ -440,32 +445,17 @@ def main(args=None):
         )
         loaded_modules = load_modules(modules_to_use=modules_to_use)
 
-        # Read in inputs from db and validate inputs for loaded modules
-        for (
-            weather_iteration
-        ) in scenario_structure.WEATHER_HYDRO_AVAIL_SUBPROBLEM_STAGE_DICT.keys():
-            for (
-                hydro_iteration
-            ) in scenario_structure.WEATHER_HYDRO_AVAIL_SUBPROBLEM_STAGE_DICT[
-                weather_iteration
-            ].keys():
-                for (
-                    availability_iteration
-                ) in scenario_structure.WEATHER_HYDRO_AVAIL_SUBPROBLEM_STAGE_DICT[
-                    weather_iteration
-                ][
-                    hydro_iteration
-                ]:
-                    validate_inputs(
-                        scenario_structure,
-                        loaded_modules,
-                        scenario_id,
-                        weather_iteration,
-                        hydro_iteration,
-                        availability_iteration,
-                        subscenarios,
-                        conn,
-                    )
+        # Read in inputs from db and validate inputs for loaded modules, for
+        # every iteration, subproblem and stage (validate_inputs loops over
+        # the scenario structure itself -- do not wrap it in another loop
+        # over the iterations)
+        validate_inputs(
+            scenario_structure,
+            loaded_modules,
+            scenario_id,
+            subscenarios,
+            conn,
+        )
 
     else:
         if not parsed_arguments.quiet:

--- a/tests/test_validate_inputs_driver.py
+++ b/tests/test_validate_inputs_driver.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Sylvan Energy Analytics LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The input-validation driver must call each module's validate_inputs exactly
+once per (weather, hydro, availability) iteration x subproblem x stage. Until
+September 2026 main() looped over the iterations around a function that
+already looped over them, so every validator ran N times per iteration for
+N iterations (two hours to validate a 15-iteration ensemble).
+"""
+
+import types
+import unittest
+from unittest import mock
+
+from gridpath import validate_inputs
+
+
+class FakeStructure:
+    # 3 weather iterations, 1 hydro, 2 availability iterations, subproblems
+    # 1 and 2 with one stage each -> 3 x 2 x 2 = 12 (iteration, subproblem,
+    # stage) cells
+    WEATHER_HYDRO_AVAIL_SUBPROBLEM_STAGE_DICT = {
+        w: {0: {a: {1: [1], 2: [1]} for a in (1, 2)}} for w in (2019, 2020, 2021)
+    }
+    STAGE_FLAG = False
+
+
+def _recording_module(calls, name):
+    module = types.ModuleType(name)
+
+    def validate(**kwargs):
+        calls.append(
+            (
+                name,
+                kwargs["weather_iteration"],
+                kwargs["hydro_iteration"],
+                kwargs["availability_iteration"],
+                kwargs["subproblem"],
+                kwargs["stage"],
+            )
+        )
+
+    module.validate_inputs = validate
+    return module
+
+
+class TestValidateInputsDriver(unittest.TestCase):
+    def test_each_module_validates_each_cell_exactly_once(self):
+        calls = []
+        modules = [
+            _recording_module(calls, "mod_a"),
+            _recording_module(calls, "mod_b"),
+            types.ModuleType("no_validator"),
+        ]
+        validate_inputs.validate_inputs(
+            scenario_structure=FakeStructure(),
+            loaded_modules=modules,
+            scenario_id=1,
+            subscenarios=object(),
+            conn=object(),
+        )
+        self.assertEqual(len(calls), 2 * 12)
+        self.assertEqual(len(set(calls)), len(calls))  # no cell validated twice
+        expected_cells = {
+            (w, 0, a, sp, 1)
+            for w in (2019, 2020, 2021)
+            for a in (1, 2)
+            for sp in (1, 2)
+        }
+        self.assertEqual({c[1:] for c in calls if c[0] == "mod_a"}, expected_cells)
+
+    def test_main_calls_the_driver_once_per_scenario(self):
+        # main() must not loop over the iterations around validate_inputs()
+        # (that was the N-squared bug) -- pin it by counting the calls made
+        # for a multi-iteration structure with everything else stubbed out
+        fake_conn = mock.MagicMock()
+        with (
+            mock.patch.object(
+                validate_inputs, "connect_to_database", return_value=fake_conn
+            ),
+            mock.patch.object(
+                validate_inputs, "get_scenario_id_and_name", return_value=(1, "s")
+            ),
+            mock.patch.object(validate_inputs, "reset_input_validation"),
+            mock.patch.object(validate_inputs, "OptionalFeatures") as features,
+            mock.patch.object(validate_inputs, "SubScenarios"),
+            mock.patch.object(
+                validate_inputs,
+                "get_scenario_structure_from_db",
+                return_value=FakeStructure(),
+            ),
+            mock.patch.object(
+                validate_inputs, "validate_subscenario_ids", return_value=True
+            ),
+            mock.patch.object(validate_inputs, "determine_modules", return_value=[]),
+            mock.patch.object(validate_inputs, "load_modules", return_value=[]),
+            mock.patch.object(validate_inputs, "update_validation_status"),
+            mock.patch.object(validate_inputs, "validate_inputs") as driver,
+        ):
+            features.return_value.get_active_features.return_value = []
+            validate_inputs.main(
+                ["--database", "unused.db", "--scenario_id", "1", "--quiet"]
+            )
+
+        self.assertEqual(driver.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Input validation of weather-year ensembles was slow enough to be a workflow problem: 14 minutes for an 8,760-hour scenario with 5 weather iterations, two hours with 15. cProfile on the 5-iteration scenario (828 s total) found two independent causes, each measured:

1. **N-squared driver loop.** `validate_inputs.validate_inputs()` loops over every iteration × subproblem × stage itself, and `main()` also looped over the iterations and called it once per iteration (since the RA Toolkit integration), so every module validator ran N times per iteration. The horizons validator was called 25 times for 5 iterations and 225 times for 15.
2. **Dead 31-second query.** `gridpath/temporal/operations/horizons.py::validate_inputs` queried the `periods_horizons` view and never used the result. The view joins `inputs_temporal` to `inputs_temporal_horizon_timepoints` `USING (temporal_scenario_id, stage_id, timepoint)`; `subproblem_id` is the second column of the horizon-timepoints primary key, so the join could use only the leading column and scanned every horizon-timepoint row of the temporal scenario for each of the 8,760 timepoints: 31.4 of the 32 s each iteration's validation took.

## Fix

- `main()` calls the driver once per scenario; the driver's unused iteration arguments are removed (no other callers).
- The dead query is removed from the horizons validator.
- The `periods_horizons` view's join gains `subproblem_id` so any consumer gets an index-backed join (verified identical rows on a real database: 372 rows, 31.7 s → 0.045 s). New databases get the new definition; existing ones keep the old view, which no longer matters for validation.

## Measured

- Horizons validator: 31.5 s → 0.04 s per call (real 15-iteration ensemble database).
- Per-iteration validation of that scenario: ~32 s × N repeats → under a second, once.

## Tests

- `tests/test_validate_inputs_driver.py`: one validation per module per cell, one driver call per scenario for a multi-iteration structure (DB stubbed). The second test fails on the previous `main()` (6 calls for 6 iterations, checked by running it against the old module).
- `python scripts/run_tests_parallel.py`: 1110 + 24 + 13 passed; `black --check .` clean. The example scenarios still validate to zero rows through the CLI path.
